### PR TITLE
MARK: Let BugSplat catch errors after io.js starts up.

### DIFF
--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -1,6 +1,11 @@
 {
   'target_defaults': {
     'conditions': [
+      ['OS=="mac"', {
+        'xcode_settings': {
+          'SKIP_INSTALL': 'YES'
+        }
+      }],
       ['OS!="win"', {
         'defines': [
           '_DARWIN_USE_64_BIT_INODE=1',

--- a/deps/http_parser/http_parser.gyp
+++ b/deps/http_parser/http_parser.gyp
@@ -39,6 +39,11 @@
       },
     },
     'conditions': [
+      ['OS=="mac"', {
+        'xcode_settings': {
+          'SKIP_INSTALL': 'YES'
+        }
+      }],
       ['OS == "win"', {
         'defines': [
           'WIN32'

--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -105,6 +105,11 @@
     'include_dirs': ['<@(openssl_default_include_dirs)'],
     'defines': ['<@(openssl_default_defines_all)'],
     'conditions': [
+      ['OS=="mac"', {
+        'xcode_settings': {
+          'SKIP_INSTALL': 'YES'
+        }
+      }],
       ['OS=="win"', {
         'defines': ['<@(openssl_default_defines_win)'],
         'link_settings': {

--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -1,6 +1,11 @@
 {
   'target_defaults': {
     'conditions': [
+      ['OS=="mac"', {
+        'xcode_settings': {
+          'SKIP_INSTALL': 'YES'
+        }
+      }],
       ['OS != "win"', {
         'defines': [
           '_LARGEFILE_SOURCE',

--- a/deps/v8/tools/gyp/v8.gyp
+++ b/deps/v8/tools/gyp/v8.gyp
@@ -35,6 +35,11 @@
   },
   'includes': ['../../build/toolchain.gypi', '../../build/features.gypi'],
   'conditions': [
+    ['OS=="mac"', {
+      'xcode_settings': {
+        'SKIP_INSTALL': 'YES'
+      }
+    }],
     ['OS=="win"', {
       'variables': {
         'gyp_generators': '<!(echo $GYP_GENERATORS)',

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -7,6 +7,11 @@
     'use_system_zlib%': 0
   },
   'conditions': [
+    ['OS=="mac"', {
+      'xcode_settings': {
+        'SKIP_INSTALL': 'YES'
+      }
+    }],
     ['use_system_zlib==0', {
       'targets': [
         {

--- a/node.gyp
+++ b/node.gyp
@@ -220,7 +220,7 @@
                 './deps/openssl/openssl.gyp:openssl',
 
                 # For tests
-                './deps/openssl/openssl.gyp:openssl-cli',
+                # DISABLED FOR ARTILLERY/ATLASRUNNER - './deps/openssl/openssl.gyp:openssl-cli',
               ],
               # Do not let unused OpenSSL symbols to slip away
               'conditions': [

--- a/node.gyp
+++ b/node.gyp
@@ -370,6 +370,10 @@
             # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
             'NODE_PLATFORM="darwin"',
           ],
+          # ARTILLERY - Embedding io.js as a shared lib in the app bundle.
+          'xcode_settings': {
+            'SKIP_INSTALL': 'YES'
+          },
         }],
         [ 'OS=="freebsd"', {
           'libraries': [

--- a/src/node.cc
+++ b/src/node.cc
@@ -3539,20 +3539,7 @@ inline void PlatformInit() {
 
   CHECK_EQ(err, 0);
 
-  // Restore signal dispositions, the parent process may have changed them.
-  struct sigaction act;
-  memset(&act, 0, sizeof(act));
-
-  // The hard-coded upper limit is because NSIG is not very reliable; on Linux,
-  // it evaluates to 32, 34 or 64, depending on whether RT signals are enabled.
-  // Counting up to SIGRTMIN doesn't work for the same reason.
-  for (unsigned nr = 1; nr < 32; nr += 1) {
-    if (nr == SIGKILL || nr == SIGSTOP)
-      continue;
-    act.sa_handler = (nr == SIGPIPE) ? SIG_IGN : SIG_DFL;
-    CHECK_EQ(0, sigaction(nr, &act, nullptr));
-  }
-
+  RegisterSignalHandler(SIGPIPE, SIG_IGN);
   RegisterSignalHandler(SIGINT, SignalExit, true);
   RegisterSignalHandler(SIGTERM, SignalExit, true);
 


### PR DESCRIPTION
## Review after #9

Revert "src: set default signal dispositions at start-up"

This change reverts dd47a8c78547db14ea0c7fc2f3375e8c9cb1a129 which prevents BugSplat from catching crashes.
